### PR TITLE
[FIX] restrap:  Allow template to be upgraded

### DIFF
--- a/restrap/report/report_deliveryslip.xml
+++ b/restrap/report/report_deliveryslip.xml
@@ -44,8 +44,8 @@
                 </div>
             </xpath>
 
-            <xpath expr="//div[@name='div_incoming_address']/div[3]" position="replace">
-            </xpath>
+            <!-- <xpath expr="//div[@name='div_incoming_address']/div[3]" position="replace">
+            </xpath> -->
 
             <xpath expr="//div[@name='partner_header']" position="replace">
                 <div t-if="partner and not o.picking_type_id.code=='outgoing'" name="partner_header">


### PR DESCRIPTION
Remove the redundant xpath causing the error.

Ticket: Restrap: Barcode Issue (#73562)
https://smart-ltd.co.uk/web#id=73562&menu_id=272&cids=1&action=818&model=helpdesk.ticket&view_type=form